### PR TITLE
Return JSON if requested

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -67,10 +67,10 @@ export async function handleRequestWrapper(
     const headers = { "Access-Control-Allow-Origin": "*" };
 
     if ((request.headers.get("accept") || "").includes("json")) {
-      returnBody = JSON.stringify({ error: err.message });
+      returnBody = JSON.stringify({ error: err.errorType });
       headers["content-type"] = "application/json;charset=UTF-8";
     } else {
-      returnBody = err.message;
+      returnBody = err.errorType;
     }
 
     return new Response(returnBody, {

--- a/src/router.ts
+++ b/src/router.ts
@@ -62,9 +62,20 @@ export async function handleRequestWrapper(
     }
     sentry.addBreadcrumb({ message: err.message });
     sentry.captureException(err);
-    return new Response(err.errorType, {
+
+    let returnBody: string;
+    const headers = { "Access-Control-Allow-Origin": "*" };
+
+    if ((request.headers.get("accept") || "").includes("json")) {
+      returnBody = JSON.stringify({ error: err.message });
+      headers["content-type"] = "application/json;charset=UTF-8";
+    } else {
+      returnBody = err.message;
+    }
+
+    return new Response(returnBody, {
       status: err.code,
-      headers: { "Access-Control-Allow-Origin": "*" },
+      headers,
     });
   }
 }

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -30,7 +30,7 @@ export async function newsletterHandler(
 
   if (!formData.has("email")) {
     throw new ServiceError(
-      "Missing email param",
+      "Missing email",
       NewsletterErrorType.MISSING_EMAIL,
       400
     );

--- a/tests/newsletter.handler.spec.ts
+++ b/tests/newsletter.handler.spec.ts
@@ -45,7 +45,7 @@ describe("Handler", function () {
     MockEvent.request.method = "GET";
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("not_valid");
+    expect(result).toBe("Invalid request");
     expect(response.status).toBe(400);
   });
 
@@ -53,7 +53,7 @@ describe("Handler", function () {
     MockEvent.request.url = "https://services.home-assistant.io/newsletter/bad";
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("not_valid");
+    expect(result).toBe("Invalid request");
     expect(response.status).toBe(400);
   });
 
@@ -66,7 +66,7 @@ describe("Handler", function () {
     );
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("not_valid");
+    expect(result).toBe("Invalid request");
     expect(response.status).toBe(400);
   });
 
@@ -76,16 +76,18 @@ describe("Handler", function () {
     });
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("missing_email");
+    expect(result).toBe("Missing email");
     expect(response.status).toBe(400);
   });
 
   it("Failed subscription", async () => {
     (global as any).fetch = async () =>
-      new MockResponse('{"error": {"message": "test"}}', { ok: false });
+      new MockResponse('{"error": {"message": "Test error message"}}', {
+        ok: false,
+      });
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("subscription");
+    expect(result).toBe("Test error message");
     expect(response.status).toBe(500);
   });
 });

--- a/tests/newsletter.handler.spec.ts
+++ b/tests/newsletter.handler.spec.ts
@@ -45,7 +45,7 @@ describe("Handler", function () {
     MockEvent.request.method = "GET";
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Invalid request");
+    expect(result).toBe("not_valid");
     expect(response.status).toBe(400);
   });
 
@@ -53,7 +53,7 @@ describe("Handler", function () {
     MockEvent.request.url = "https://services.home-assistant.io/newsletter/bad";
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Invalid request");
+    expect(result).toBe("not_valid");
     expect(response.status).toBe(400);
   });
 
@@ -66,7 +66,7 @@ describe("Handler", function () {
     );
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Invalid request");
+    expect(result).toBe("not_valid");
     expect(response.status).toBe(400);
   });
 
@@ -76,7 +76,7 @@ describe("Handler", function () {
     });
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Missing email");
+    expect(result).toBe("missing_email");
     expect(response.status).toBe(400);
   });
 
@@ -87,7 +87,7 @@ describe("Handler", function () {
       });
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Test error message");
+    expect(result).toBe("subscription");
     expect(response.status).toBe(500);
   });
 });

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -32,7 +32,7 @@ describe("Handler", function () {
     );
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.json<Record<string, any>>();
-    expect(result.error).toBe("Invalid request");
+    expect(result.error).toBe("not_valid");
   });
 
   it("Return error as text (with accept header)", async () => {
@@ -45,7 +45,7 @@ describe("Handler", function () {
     );
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Invalid request");
+    expect(result).toBe("not_valid");
   });
 
   it("Return error as text (without accept header)", async () => {
@@ -57,6 +57,6 @@ describe("Handler", function () {
     );
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.text();
-    expect(result).toBe("Invalid request");
+    expect(result).toBe("not_valid");
   });
 });

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -1,0 +1,62 @@
+import { MockedSentry, MockResponse } from "./mock";
+import { routeRequest } from "../src/router";
+
+describe("Handler", function () {
+  let MockRequest: any;
+  let MockEvent: any;
+  let MockSentry: any;
+  let MockRequestUrl: URL;
+
+  beforeEach(() => {
+    MockSentry = MockedSentry();
+    (global as any).Response = MockResponse;
+    const headers: Map<string, string> = new Map(
+      Object.entries({ "CF-Connecting-IP": "1.2.3.4" })
+    );
+    MockRequestUrl = new URL("https://services.home-assistant.io/newsletter");
+    MockRequest = {
+      url: MockRequestUrl.href,
+      method: "GET",
+      headers,
+    };
+    MockEvent = { request: MockRequest };
+  });
+
+  it("Return error as JSON", async () => {
+    MockEvent.request.headers = new Map(
+      Object.entries({
+        "CF-Connecting-IP": "1.2.3.4",
+        "content-type": "json",
+        accept: "application/json",
+      })
+    );
+    const response = await routeRequest(MockSentry, MockEvent);
+    const result = await response.json<Record<string, any>>();
+    expect(result.error).toBe("Invalid request");
+  });
+
+  it("Return error as text (with accept header)", async () => {
+    MockEvent.request.headers = new Map(
+      Object.entries({
+        "CF-Connecting-IP": "1.2.3.4",
+        "content-type": "json",
+        accept: "application/text",
+      })
+    );
+    const response = await routeRequest(MockSentry, MockEvent);
+    const result = await response.text();
+    expect(result).toBe("Invalid request");
+  });
+
+  it("Return error as text (without accept header)", async () => {
+    MockEvent.request.headers = new Map(
+      Object.entries({
+        "CF-Connecting-IP": "1.2.3.4",
+        "content-type": "json",
+      })
+    );
+    const response = await routeRequest(MockSentry, MockEvent);
+    const result = await response.text();
+    expect(result).toBe("Invalid request");
+  });
+});


### PR DESCRIPTION
If the request have "json" in the `accept` header, return the error as `{error: err.message}`