### PR TITLE
Update currency.ts

### DIFF
--- a/src/data/currency.ts
+++ b/src/data/currency.ts
@@ -214,7 +214,7 @@ export const countryCurrency = {
   LI: "CHF",
   LV: "EUR",
   TO: "TOP",
-  LT: "LTL",
+  LT: "EUR",
   LU: "EUR",
   LR: "LRD",
   LS: "LSL",


### PR DESCRIPTION
Lithuania adopted `EUR` currency since 2015.
https://en.wikipedia.org/wiki/Lithuania