### PR TITLE
Bump @cloudflare/workers-types from 3.17.0 to 3.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.17.0",
+    "@cloudflare/workers-types": "^3.18.0",
     "@cloudflare/wrangler": "^1.19.12",
     "@types/jest": "^27.5.0",
     "@types/node": "^18.11.9",

--- a/src/common.ts
+++ b/src/common.ts
@@ -20,3 +20,7 @@ export const sentryClient = (event: FetchEvent | ScheduledEvent) => {
   });
   return client;
 };
+
+export interface CfRequest extends Request {
+  cf?: IncomingRequestCfProperties;
+}

--- a/src/services/whoami.ts
+++ b/src/services/whoami.ts
@@ -1,5 +1,5 @@
 import Toucan from "toucan-js";
-import { ServiceError } from "../common";
+import { CfRequest, ServiceError } from "../common";
 import { countryCurrency } from "../data/currency";
 
 const REQUIRED_KEYS = ["country", "timezone"];
@@ -16,11 +16,15 @@ export enum WhoamiErrorType {
 
 export async function whoamiHandler(
   requestUrl: URL,
-  request: Request,
+  request: CfRequest,
   sentry: Toucan
 ): Promise<Response> {
   if (request.method !== "GET") {
     return new Response(null, { status: 405 });
+  }
+
+  if (!request.cf || !("continent" in request.cf)) {
+    return new Response(null, { status: 400 });
   }
 
   if (!requestUrl.pathname.startsWith("/whoami/v1")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,10 +287,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.17.0.tgz#8cee4499019daa6a23c9cc5501aa8382bb94d4da"
-  integrity sha512-u0cUQ4ntWFFwn5jx0ETa2ItvwvfOMjyaKF2fX2vFVujrSgNES/PnvRzPAhdt9CMYAMidInm0MGkIjxHRsFBaeg==
+"@cloudflare/workers-types@^3.18.0":
+  version "3.18.0"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.18.0.tgz#b4177cbe9306d7df4654db594d6e77c036341d2e"
+  integrity sha512-ehKOJVLMeR+tZkYhWEaLYQxl0TaIZu/kE86HF3/RidR8Xv5LuQxpbh+XXAoKVqsaphWLhIgBhgnlN5HGdheXSQ==
 
 "@cloudflare/wrangler@^1.19.12":
   version "1.19.12"


### PR DESCRIPTION
Replaces #272 with the adjustments needed to use that version
