### PR TITLE
Bump @cloudflare/workers-types to 4.20221111.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@cloudflare/workers-types": "^3.17.0",
+    "@cloudflare/workers-types": "^4.20221111.1",
     "@cloudflare/wrangler": "^1.19.12",
     "@types/jest": "^27.5.0",
     "@types/node": "^18.11.9",

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,5 +1,9 @@
 import Toucan from "toucan-js";
 
+export interface CfRequest extends Request {
+  cf?: IncomingRequestCfProperties;
+}
+
 export class ServiceError extends Error {
   code: number;
   errorType?: string;

--- a/src/services/whoami.ts
+++ b/src/services/whoami.ts
@@ -1,5 +1,5 @@
 import Toucan from "toucan-js";
-import { ServiceError } from "../common";
+import { CfRequest, ServiceError } from "../common";
 import { countryCurrency } from "../data/currency";
 
 const REQUIRED_KEYS = ["country", "timezone"];
@@ -16,7 +16,7 @@ export enum WhoamiErrorType {
 
 export async function whoamiHandler(
   requestUrl: URL,
-  request: Request,
+  request: CfRequest,
   sentry: Toucan
 ): Promise<Response> {
   if (request.method !== "GET") {
@@ -29,6 +29,10 @@ export async function whoamiHandler(
       "https://github.com/home-assistant/services.home-assistant.io",
       301
     );
+  }
+
+  if (!request.cf || !("continent" in request.cf)) {
+    return new Response(null, { status: 400 });
   }
 
   const date = new Date();

--- a/tests/whoami.handler.spec.ts
+++ b/tests/whoami.handler.spec.ts
@@ -20,7 +20,7 @@ describe("Handler", function () {
       url: MockRequestUrl.href,
       method: "GET",
       headers,
-      cf: { country: "XX", timezone: "Earth/Gotham" },
+      cf: { country: "XX", timezone: "Earth/Gotham", continent: "Elsa Island" },
     };
     MockEvent = { request: MockRequest };
   });
@@ -49,7 +49,11 @@ describe("Handler", function () {
 
   it("Request single key", async () => {
     MockEvent.request.url = "https://whoami.home-assistant.io/v1/ip";
-    MockEvent.request.cf = { country: "XX", timezone: undefined };
+    MockEvent.request.cf = {
+      country: "XX",
+      timezone: undefined,
+      continent: "Elsa Island",
+    };
     const response = await routeRequest(MockSentry, MockEvent);
 
     const result = await response.text();
@@ -58,7 +62,11 @@ describe("Handler", function () {
 
   it("Request invalid key", async () => {
     MockEvent.request.url = "http://whoami.home-assistant.io/v1/invalid";
-    MockEvent.request.cf = { country: "XX", timezone: undefined };
+    MockEvent.request.cf = {
+      country: "XX",
+      timezone: undefined,
+      continent: "Elsa Island",
+    };
     const response = await routeRequest(MockSentry, MockEvent);
 
     expect(response.status).toBe(405);
@@ -81,7 +89,11 @@ describe("Handler", function () {
 
   it("Missing required key", async () => {
     MockEvent.request.url = "http://whoami.home-assistant.io/v1";
-    MockEvent.request.cf = { country: "XX", timezone: undefined };
+    MockEvent.request.cf = {
+      country: "XX",
+      timezone: undefined,
+      continent: "Elsa Island",
+    };
     const response = await routeRequest(MockSentry, MockEvent);
 
     expect(response.status).toBe(500);

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,10 +287,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@cloudflare/workers-types@^3.17.0":
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-3.17.0.tgz#8cee4499019daa6a23c9cc5501aa8382bb94d4da"
-  integrity sha512-u0cUQ4ntWFFwn5jx0ETa2ItvwvfOMjyaKF2fX2vFVujrSgNES/PnvRzPAhdt9CMYAMidInm0MGkIjxHRsFBaeg==
+"@cloudflare/workers-types@^4.20221111.1":
+  version "4.20221111.1"
+  resolved "https://registry.yarnpkg.com/@cloudflare/workers-types/-/workers-types-4.20221111.1.tgz#c3dbb5ef52cf5fab275803ece0424b205c78ad3e"
+  integrity sha512-BNV2wN8V6Zduvo7UzxcdjBbLQ906D2KhS804PDufLgx/sanGJCHVJMOIaLvS/b61JKtot1U7P/l1fjrjZ7/E3A==
 
 "@cloudflare/wrangler@^1.19.12":
   version "1.19.12"


### PR DESCRIPTION
Replaces https://github.com/home-assistant/services.home-assistant.io/pull/280
Replaces https://github.com/home-assistant/services.home-assistant.io/pull/276
Replaces https://github.com/home-assistant/services.home-assistant.io/pull/272

Necessary changes to types and test files are also done in this PR.