### PR TITLE
EUR for Croatia

### DIFF
--- a/src/data/currency.ts
+++ b/src/data/currency.ts
@@ -59,7 +59,7 @@ export const countryCurrency = {
   OM: "OMR",
   TN: "TND",
   JO: "JOD",
-  HR: "HRK",
+  HR: "EUR",
   HT: "HTG",
   HU: "HUF",
   HK: "HKD",


### PR DESCRIPTION
As of January first, 2023 Croatia adopted EUR as its currency.
