### PR TITLE
Use wrangler version from package.json in actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ on:
       - published
 
 env:
-  WRANGLER_VERSION: "3.5.1"
   NODE_VERSION: "16.14.0"
 
 jobs:
@@ -22,6 +21,10 @@ jobs:
       - uses: actions/setup-node@v3.8.1
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Set wrangler version
+        id: wrangler
+        run: echo "version=$(jq -r .devDependencies.wrangler package.json | cut -c2-)" >> "$GITHUB_OUTPUT"
 
       - name: Install packages
         run: yarn install
@@ -39,5 +42,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3.1.0
         with:
           apiToken: ${{ secrets.CF_WORKER_API_TOKEN }}
-          wranglerVersion: ${{ env.WRANGLER_VERSION }}
+          wranglerVersion: ${{ steps.wrangler.outputs.version }}
           command: deploy --env=${{ steps.environment.outputs.environment }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,6 @@ on:
       - main
 
 env:
-  WRANGLER_VERSION: "3.5.1"
   NODE_VERSION: "16.14.0"
 
 jobs:
@@ -25,13 +24,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Set wrangler version
+        id: wrangler
+        run: echo "version=$(jq -r .devDependencies.wrangler package.json | cut -c2-)" >> "$GITHUB_OUTPUT"
+
       - name: Install packages
         run: yarn install
 
       - name: Build ${{ matrix.environment }} worker
         uses: cloudflare/wrangler-action@v3.1.0
         with:
-          wranglerVersion: ${{ env.WRANGLER_VERSION }}
+          wranglerVersion: ${{ steps.wrangler.outputs.version }}
           command: deploy --dry-run --env=${{ matrix.environment }}
 
   test:


### PR DESCRIPTION
When looking at dependabot updates like https://github.com/home-assistant/services.home-assistant.io/pull/408

All those need manual changes before they can be merged, as this is used in actions as well. As this has to be manual, it will be forgotten at some point.

This PR aims to remove the possibility of not bumping the action version by simply referencing the version defined in package.json