### PR TITLE
Use NodeJS version from .nvmrc in actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,9 +8,6 @@ on:
     types:
       - published
 
-env:
-  NODE_VERSION: "16.14.0"
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,9 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.0
 
+      - name: Set NodeJS version
+        id: node
+        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ steps.node.outputs.version }}
 
       - name: Set wrangler version
         id: wrangler

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  NODE_VERSION: "16.14.0"
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,9 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.0
 
+      - name: Set NodeJS version
+        id: node
+        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ steps.node.outputs.version }}
 
       - name: Set wrangler version
         id: wrangler

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,9 +44,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.0
 
+      - name: Set NodeJS version
+        id: node
+        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-node@v3.8.1
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ steps.node.outputs.version }}
 
       - name: Install packages
         run: yarn install


### PR DESCRIPTION
Similar to #412, while this is not updated by dependabot it is a place that can be forgotten when bumping node versions.