### PR TITLE
Refactor fetch definition (entrypoint)

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,20 @@
 import { Toucan } from "toucan-js";
 
+export interface WorkerEnv {
+  SENTRY_DSN: string;
+  WORKER_ENV: string;
+  MAILERLITE_API_KEY: string;
+  WAKEWORD_TRAINING_BUCKET: R2Bucket;
+}
+
 export interface CfRequest extends Request {
   cf?: IncomingRequestCfProperties;
+}
+
+export interface WorkerEvent {
+  request: CfRequest;
+  env: WorkerEnv;
+  ctx: ExecutionContext;
 }
 
 export class ServiceError extends Error {
@@ -15,14 +28,14 @@ export class ServiceError extends Error {
   }
 }
 
-export const sentryClient = (event: FetchEvent) => {
+export const sentryClient = (event: WorkerEvent) => {
   const client = new Toucan({
-    dsn: SENTRY_DSN,
+    dsn: event.env.SENTRY_DSN,
     requestDataOptions: {
       allowedHeaders: ["user-agent"],
     },
     request: event.request,
-    environment: WORKER_ENV,
+    environment: event.env.WORKER_ENV,
   });
   return client;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,10 @@
-import { sentryClient } from "./common";
+import { WorkerEvent, sentryClient } from "./common";
 import { routeRequest } from "./router";
 
-declare global {
-  const SENTRY_DSN: string;
-  const WORKER_ENV: string;
-  const MAILERLITE_API_KEY: string;
-  const WAKEWORD_TRAINING_BUCKET: R2Bucket;
-}
-
-addEventListener("fetch", (event: FetchEvent) => {
-  event.respondWith(routeRequest(sentryClient(event), event));
-});
+export default {
+  fetch: async (
+    request: WorkerEvent["request"],
+    env: WorkerEvent["env"],
+    ctx: WorkerEvent["ctx"]
+  ) => routeRequest(sentryClient({ request, env, ctx }), { request, env, ctx }),
+};

--- a/src/services/newsletter.ts
+++ b/src/services/newsletter.ts
@@ -1,5 +1,5 @@
 import { Toucan } from "toucan-js";
-import { CfRequest, ServiceError } from "../common";
+import { ServiceError, WorkerEvent } from "../common";
 
 const MAILERLITE_API = "https://api.mailerlite.com/api/v2/subscribers";
 
@@ -12,9 +12,10 @@ export enum NewsletterErrorType {
 
 export async function newsletterHandler(
   requestUrl: URL,
-  request: CfRequest,
+  event: WorkerEvent,
   sentry: Toucan
 ): Promise<Response> {
+  const { request } = event;
   if (
     request.method !== "POST" ||
     requestUrl.pathname !== "/newsletter/signup" ||
@@ -50,7 +51,7 @@ export async function newsletterHandler(
       body: JSON.stringify({ email }),
       headers: {
         "Content-Type": "application/json",
-        "X-MailerLite-ApiKey": MAILERLITE_API_KEY,
+        "X-MailerLite-ApiKey": event.env.MAILERLITE_API_KEY,
       },
     });
   } catch (err: any) {

--- a/src/services/whoami.ts
+++ b/src/services/whoami.ts
@@ -1,5 +1,5 @@
 import { Toucan } from "toucan-js";
-import { CfRequest, ServiceError } from "../common";
+import { ServiceError, WorkerEvent } from "../common";
 import { countryCurrency } from "../data/currency";
 
 const REQUIRED_KEYS = ["country", "timezone"];
@@ -16,9 +16,10 @@ export enum WhoamiErrorType {
 
 export async function whoamiHandler(
   requestUrl: URL,
-  request: CfRequest,
+  event: WorkerEvent,
   sentry: Toucan
 ): Promise<Response> {
+  const { request } = event;
   if (request.method !== "GET") {
     return new Response(null, { status: 405 });
   }

--- a/tests/assist.handler.spec.ts
+++ b/tests/assist.handler.spec.ts
@@ -1,24 +1,18 @@
 import { MockedSentry, MockResponse } from "./mock";
 import { routeRequest } from "../src/router";
 import { webcrypto } from "crypto";
+import { WorkerEvent } from "../src/common";
 
 describe("Assist handler", function () {
   let MockRequest: any;
-  let MockEvent: any;
+  let MockEvent: WorkerEvent;
   let MockSentry: any;
   let MockRequestUrl: URL;
 
   beforeAll(() => {
-    (global as any).WAKEWORD_TRAINING_BUCKET = {
-      put: jest.fn(),
-    };
     (global as any).crypto = {
       subtle: webcrypto.subtle,
     };
-  });
-
-  afterEach(() => {
-    (global as any).WAKEWORD_TRAINING_BUCKET.put.mockClear();
   });
 
   beforeEach(() => {
@@ -44,10 +38,22 @@ describe("Assist handler", function () {
         get: () => "test@test.test",
       }),
     };
-    MockEvent = { request: MockRequest };
+    MockEvent = {
+      request: MockRequest,
+      env: {
+        SENTRY_DSN: "",
+        WORKER_ENV: "test",
+        MAILERLITE_API_KEY: "abc123",
+        WAKEWORD_TRAINING_BUCKET: {
+          put: jest.fn(),
+        } as unknown as R2Bucket,
+      },
+      ctx: {} as unknown as ExecutionContext,
+    };
   });
 
   it("rejects if not the right HTTP method", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.method = "GET";
     const response = await routeRequest(MockSentry, MockEvent);
     const result = await response.json();
@@ -56,12 +62,14 @@ describe("Assist handler", function () {
   });
 
   it("rejects if not the exact path", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.url = "https://services.home-assistant.io/assist/unknown";
     const response = await routeRequest(MockSentry, MockEvent);
     expect(response.status).toBe(404);
   });
 
   it("rejects when called with bad content-type", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.headers = new Map(
       Object.entries({
         "CF-Connecting-IP": "1.2.3.4",
@@ -75,6 +83,7 @@ describe("Assist handler", function () {
   });
 
   it("rejects when called to big file", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.headers = new Map(
       Object.entries({
         "CF-Connecting-IP": "1.2.3.4",
@@ -89,6 +98,7 @@ describe("Assist handler", function () {
   });
 
   it("rejects when missing speed", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.url =
       "https://services.home-assistant.io/assist/wake_word/training_data/upload?distance=400&wake_word=ok_nabu";
     const response = await routeRequest(MockSentry, MockEvent);
@@ -100,6 +110,7 @@ describe("Assist handler", function () {
   });
 
   it("rejects when missing distance", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.url =
       "https://services.home-assistant.io/assist/wake_word/training_data/upload?speed=4&wake_word=ok_nabu";
     const response = await routeRequest(MockSentry, MockEvent);
@@ -111,6 +122,7 @@ describe("Assist handler", function () {
   });
 
   it("rejects when missing wake_word", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.url =
       "https://services.home-assistant.io/assist/wake_word/training_data/upload?speed=4&distance=400";
     const response = await routeRequest(MockSentry, MockEvent);
@@ -122,6 +134,7 @@ describe("Assist handler", function () {
   });
 
   it("rejects when unkown wake_word", async () => {
+    // @ts-expect-error overriding read-only property
     MockEvent.request.url =
       "https://services.home-assistant.io/assist/wake_word/training_data/upload?speed=4&distance=400&wake_word=unknown";
     const response = await routeRequest(MockSentry, MockEvent);
@@ -139,10 +152,8 @@ describe("Assist handler", function () {
     expect(response.status).toBe(201);
     expect(result.message).toStrictEqual("success");
     expect(result.key.endsWith(".webm")).toBeTruthy();
-    expect((global as any).WAKEWORD_TRAINING_BUCKET.put).toHaveBeenCalledTimes(
-      1
-    );
-    expect((global as any).WAKEWORD_TRAINING_BUCKET.put).toBeCalledWith(
+    expect(MockEvent.env.WAKEWORD_TRAINING_BUCKET.put).toHaveBeenCalledTimes(1);
+    expect(MockEvent.env.WAKEWORD_TRAINING_BUCKET.put).toBeCalledWith(
       result.key,
       expect.anything()
     );


### PR DESCRIPTION
A while back Cloudflare changed how workers should be defined from the old style event listener to the new exported handler.

This PR migrates the worker in this repository to the new style.