### PR TITLE
Add context and ray-id to sentry

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -34,6 +34,7 @@ export const sentryClient = (event: WorkerEvent) => {
     requestDataOptions: {
       allowedHeaders: ["user-agent"],
     },
+    context: event.ctx,
     request: event.request,
     environment: event.env.WORKER_ENV,
   });

--- a/tests/assist.handler.spec.ts
+++ b/tests/assist.handler.spec.ts
@@ -1,4 +1,4 @@
-import { MockedSentry, MockResponse } from "./mock";
+import { MockedConsole, MockedSentry, MockResponse } from "./mock";
 import { routeRequest } from "../src/router";
 import { webcrypto } from "crypto";
 import { WorkerEvent } from "../src/common";
@@ -19,6 +19,7 @@ describe("Assist handler", function () {
     MockSentry = MockedSentry();
     (global as any).Response = MockResponse;
     (global as any).fetch = async () => new MockResponse("");
+    (global as any).console = MockedConsole();
 
     MockRequestUrl = new URL(
       "https://services.home-assistant.io/assist/wake_word/training_data/upload?distance=400&speed=3&wake_word=ok_nabu"

--- a/tests/mock.ts
+++ b/tests/mock.ts
@@ -8,6 +8,12 @@ export const MockedSentry = () => ({
   captureMessage: jest.fn(),
 });
 
+export const MockedConsole = () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+});
+
 export class MockResponse {
   body: string;
   status: number = 200;

--- a/tests/newsletter.handler.spec.ts
+++ b/tests/newsletter.handler.spec.ts
@@ -1,4 +1,4 @@
-import { MockedSentry, MockResponse } from "./mock";
+import { MockedConsole, MockedSentry, MockResponse } from "./mock";
 import { routeRequest } from "../src/router";
 import { SUCCESS_MESSAGE } from "../src/services/newsletter";
 import { WorkerEvent } from "../src/common";
@@ -13,6 +13,7 @@ describe("Handler", function () {
     MockSentry = MockedSentry();
     (global as any).Response = MockResponse;
     (global as any).fetch = async () => new MockResponse("");
+    (global as any).console = MockedConsole();
 
     MockRequestUrl = new URL(
       "https://services.home-assistant.io/newsletter/signup"

--- a/tests/router.spec.ts
+++ b/tests/router.spec.ts
@@ -1,4 +1,4 @@
-import { MockedSentry, MockResponse } from "./mock";
+import { MockedConsole, MockedSentry, MockResponse } from "./mock";
 import { routeRequest } from "../src/router";
 
 describe("Handler", function () {
@@ -8,8 +8,9 @@ describe("Handler", function () {
   let MockRequestUrl: URL;
 
   beforeEach(() => {
-    MockSentry = MockedSentry();
+    (global as any).console = MockedConsole();
     (global as any).Response = MockResponse;
+    MockSentry = MockedSentry();
     const headers: Map<string, string> = new Map(
       Object.entries({ "CF-Connecting-IP": "1.2.3.4" })
     );

--- a/tests/whoami.handler.spec.ts
+++ b/tests/whoami.handler.spec.ts
@@ -1,4 +1,4 @@
-import { MockedSentry, MockResponse } from "./mock";
+import { MockedConsole, MockedSentry, MockResponse } from "./mock";
 import { WhoamiErrorType } from "../src/services/whoami";
 import { routeRequest } from "../src/router";
 import { ServiceError } from "../src/common";
@@ -12,6 +12,7 @@ describe("Handler", function () {
   beforeEach(() => {
     MockSentry = MockedSentry();
     (global as any).Response = MockResponse;
+    (global as any).console = MockedConsole();
     const headers: Map<string, string> = new Map(
       Object.entries({ "CF-Connecting-IP": "1.2.3.4" })
     );


### PR DESCRIPTION
Before v3 of tucan-js the context was included in the event, when doing the migration I forgot about adding that back.

This also changes `cf-request-id` to `cf-ray-id`, as  `cf-request-id` does not exist, but `cf-ray-id` does.