### PR TITLE
Move cf-ray to allowedHeaders

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -32,7 +32,7 @@ export const sentryClient = (event: WorkerEvent) => {
   const client = new Toucan({
     dsn: event.env.SENTRY_DSN,
     requestDataOptions: {
-      allowedHeaders: ["user-agent"],
+      allowedHeaders: ["user-agent", "cf-ray"],
     },
     context: event.ctx,
     request: event.request,

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,7 +16,6 @@ export async function routeRequest(sentry: Toucan, event: WorkerEvent) {
 
   const service = requestUrl.pathname.split("/")[1];
   sentry.setTag("service", service);
-  sentry.setExtra("rayId", event.request.headers.get("cf-ray-id"));
   sentry.setExtra("requestUrl", {
     protocol: requestUrl.protocol,
     pathname: requestUrl.pathname,


### PR DESCRIPTION
Ther is no need to set this as extra. We can just allow it to be passed from the request.