### PR TITLE
Limit paths allowed for getting ICE server config

### DIFF
--- a/src/services/webrtc.ts
+++ b/src/services/webrtc.ts
@@ -32,13 +32,17 @@ const getStunDomain = (country?: string, continent?: string): string =>
   STUN_DOMAIN_ROUTING_CONFIG.default;
 
 export const webrtcHandler = async (
-  _requestUrl: URL,
+  requestUrl: URL,
   event: WorkerEvent,
   _sentry: Toucan
 ): Promise<Response> => {
   const { request } = event;
   if (request.method !== "GET") {
     return new Response(null, { status: 405 });
+  }
+
+  if (requestUrl.pathname !== "/webrtc/ice_servers") {
+    return new Response(null, { status: 404 });
   }
 
   if (!request.cf) {


### PR DESCRIPTION
We want ICE server response only on specific paths, not every `/webrtc` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for WebRTC requests, ensuring only valid endpoints are processed.
  
- **Bug Fixes**
	- Improved handling of request URLs, returning appropriate status codes for incorrect paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->