### PR TITLE
Fix the WebRTC ICE Server config format

### DIFF
--- a/src/services/webrtc.ts
+++ b/src/services/webrtc.ts
@@ -51,7 +51,7 @@ export const webrtcHandler = async (
 
   const stunDomain = getStunDomain(request.cf.country, request.cf.continent);
 
-  return new Response(JSON.stringify([{ urls: [stunDomain] }]), {
+  return new Response(JSON.stringify([{ urls: stunDomain }]), {
     headers: {
       "content-type": "application/json;charset=UTF-8",
       "Access-Control-Allow-Origin": "*",

--- a/tests/webrtc.handler.spec.ts
+++ b/tests/webrtc.handler.spec.ts
@@ -39,7 +39,7 @@ describe("WebRTC Handler", () => {
       MockEvent.request.cf.continent = continent;
       const response = await routeRequest(MockSentry, MockEvent);
       const result = await response.json<Record<string, any>>();
-      expect(result).toEqual([{ urls: [expected] }]);
+      expect(result).toEqual([{ urls: expected }]);
     });
   }
 });


### PR DESCRIPTION
Despite the `urls` being plural in the response, the value should be a string, not a list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified the JSON response structure for STUN server URLs, enhancing clarity and usability.

- **Bug Fixes**
	- Updated test cases to align with the new response structure, ensuring accurate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->