### PR TITLE
Change Stun server URLs to the correct ones for WebRTC service

### DIFF
--- a/src/services/webrtc.ts
+++ b/src/services/webrtc.ts
@@ -8,9 +8,9 @@ interface StunDomainRoutingConfig {
 }
 
 const STUN_DOMAINS = {
-  "us-east-1": "stun:44.197.212.58:3478",
-  "eu-central-1": "stun:44.197.212.58:3478",
-  "ap-southeast-1": "stun:44.197.212.58:3478",
+  "us-east-1": "stun:stun-us-east-1.home-assistant.io:3478",
+  "eu-central-1": "stun:stun-eu-central-1.home-assistant.io:3478",
+  "ap-southeast-1": "stun:stun-ap-southeast-1.home-assistant.io:3478",
 };
 
 const STUN_DOMAIN_ROUTING_CONFIG: StunDomainRoutingConfig = {

--- a/tests/webrtc.handler.spec.ts
+++ b/tests/webrtc.handler.spec.ts
@@ -27,12 +27,24 @@ describe("WebRTC Handler", () => {
   });
 
   for (const [country, continent, expected] of [
-    ["NO_CUSTOM_CONFIG", "NO_CUSTOM_CONFIG", "stun:44.197.212.58:3478"],
-    ["IL", "NOT_USED", "stun:44.197.212.58:3478"],
-    ["LB", "NOT_USED", "stun:44.197.212.58:3478"],
-    ["NO_CUSTOM_CONFIG", "EU", "stun:44.197.212.58:3478"],
-    ["NO_CUSTOM_CONFIG", "AS", "stun:44.197.212.58:3478"],
-    ["NO_CUSTOM_CONFIG", "OC", "stun:44.197.212.58:3478"],
+    [
+      "NO_CUSTOM_CONFIG",
+      "NO_CUSTOM_CONFIG",
+      "stun:stun-us-east-1.home-assistant.io:3478",
+    ],
+    ["IL", "NOT_USED", "stun:stun-eu-central-1.home-assistant.io:3478"],
+    ["LB", "NOT_USED", "stun:stun-eu-central-1.home-assistant.io:3478"],
+    ["NO_CUSTOM_CONFIG", "EU", "stun:stun-eu-central-1.home-assistant.io:3478"],
+    [
+      "NO_CUSTOM_CONFIG",
+      "AS",
+      "stun:stun-ap-southeast-1.home-assistant.io:3478",
+    ],
+    [
+      "NO_CUSTOM_CONFIG",
+      "OC",
+      "stun:stun-ap-southeast-1.home-assistant.io:3478",
+    ],
   ]) {
     it(`returns correct domains for country ${country} and continent ${continent}`, async () => {
       MockEvent.request.cf.country = country;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated STUN server configurations to use domain names instead of hardcoded IP addresses for improved reliability and regional accuracy.

- **Tests**
	- Adjusted WebRTC handler tests to reflect the new domain-based STUN server URLs for various country and continent combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->